### PR TITLE
BUG: fix and test ModelData.set_effect_prior

### DIFF
--- a/dismod_mr/data.py
+++ b/dismod_mr/data.py
@@ -401,24 +401,37 @@ class ModelData:
         """
         self.parameters[rate_type]['heterogeneity'] = value
 
-    def set_effect_prior(self, rate_type, value):
+    def set_effect_prior(self, rate_type, cov, value):
         """ Set prior for fixed or random effect of one
         type.
         
         :Parameters:
           - `rate_type` : str, one of 'i', 'r', 'f', 'p'
           - `cov` : str, covariate name
-          - `value` : dict, TODO: describe allowed values
-
+          - `value` : dict, including keys `dist`, `mu`, and possibly
+            `sigma`, `lower`, and `upper`
         
         :Results: 
           - Changes heterogeneity in self.parameters[rate_type]
 
+        :Notes:
+
+        the `value` dict describes the distribution of the effect
+        prior.  Recognized distributions are Constant, Normal, and
+        TruncatedNormal.  Examples:
+          - `value=dict(dist='Constant', mu=0)`
+          - `value=dict(dist='Normal', mu=0, sigma=1)`
+          - `value=dict(dist='TruncatedNormal, mu=0, sigma=1,
+                        lower=-1, upper=1)`
         """
+        for effects in ['fixed_effects', 'random_effects']:
+            if not effects in self.parameters[rate_type]:
+                self.parameters[rate_type][effects] = {}
+
         if cov.startswith('x_'): # fixed effect
-            model.parameters[rate_type]['fixed_effects'][cov] = value
+            self.parameters[rate_type]['fixed_effects'][cov] = value
         else: # random effect
-            model.parameters[rate_type]['random_effects'][cov] = value
+            self.parameters[rate_type]['random_effects'][cov] = value
 
 
     def setup_model(self, rate_type=None, rate_model='neg_binom',

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,6 +3,7 @@
 import pylab as pl
 import pymc as mc
 
+import dismod_mr
 from dismod_mr import data
 reload(data)
 
@@ -22,6 +23,9 @@ def test_blank_input_data():
 
     assert len(d.nodes_to_fit) > 0, 'Nodes to fit should be non-empty'
 
+def test_set_effect_prior():
+    dm = dismod_mr.data.ModelData()
+    dm.set_effect_prior('p', 'x_sex', dict(dist='Constant', mu=.1))
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
This makes the `set_effect_prior` method of the ModelData class function;  it was never completed or tested previously.  Thanks to Ver for motivating me to do it.

Now code such as

```
    dm.set_effect_prior('p', 'x_cigc', dict(dist='TruncatedNormal', mu=0., sigma=1., lower=-10., upper=0.))
```

should work and set an informative prior on the `x_cigc` effect coefficient, constraining it to be at most zero.
